### PR TITLE
feat(graph): enhance plotting support for polar coordinates #2

### DIFF
--- a/src/core/Core/Application.cpp
+++ b/src/core/Core/Application.cpp
@@ -113,7 +113,7 @@ ExitStatus App::Application::run() {
       const ImVec2 base_pos = viewport->Pos;
       const ImVec2 base_size = viewport->Size;
 
-      static char function[1024] = "tanh(x)";
+      static char function[1024] = "r = 1 + 0.5*cos(theta)";
       static float zoom = 100.0f;
 
       // Left Pane (expression)
@@ -214,7 +214,7 @@ ExitStatus App::Application::run() {
 
         if (!plotted) {
           std::string func_str(function);
-          bool is_polar = func_str.find("theta") != std::string::npos;
+          bool is_polar = func_str.find("r=") != std::string::npos || func_str.find("r =") != std::string::npos;
 
           if (is_polar) {
             double theta;
@@ -227,8 +227,19 @@ ExitStatus App::Application::run() {
             exprtk::expression<double> expression;
             expression.register_symbol_table(symbolTable);
 
+            std::string polar_function = func_str;
+            size_t eq_pos = func_str.find("r=");
+            if (eq_pos == std::string::npos) {
+              eq_pos = func_str.find("r =");
+            }
+            if (eq_pos != std::string::npos) {
+              size_t start_pos = func_str.find("=", eq_pos) + 1;
+              polar_function = func_str.substr(start_pos);
+              polar_function.erase(0, polar_function.find_first_not_of(" \t"));
+            }
+
             exprtk::parser<double> parser;
-            if (parser.compile(function, expression)) {
+            if (parser.compile(polar_function, expression)) {
               const double theta_min = 0.0;
               const double theta_max = 4.0 * M_PI;  
               const double theta_step = 0.02;


### PR DESCRIPTION

## Description

This pull request enhances the plotting functionality in `src/core/Core/Application.cpp` by adding support for **polar coordinate plots**.
Functions containing the variable `theta` are now automatically interpreted and plotted in polar form, expanding the application's graphing capabilities.

ISSUE ADDRESSED: #2 

### Plotting Improvements

* Added detection for functions using the variable `theta` to identify polar equations and plot them using polar coordinates (`r = f(theta)`), converting results to `(x, y)` for rendering.
* Implemented a loop to evaluate and plot polar functions over a range of `theta` values, drawing the corresponding polyline on the canvas.

### Codebase Updates

* Included the `<cmath>` header to support trigonometric operations required for polar plotting.

These changes enable the application to visualize both standard and polar equations seamlessly.

---

## Semver Changes

* [x] Minor (new features, no breaking changes)

---

## Issues

> None

---

## Checklist

* [x] I have read the [[Contributing Guidelines](https://chatgpt.com/Contributor_Guide/Contruting.md)](../Contributor_Guide/Contruting.md).

## ATTACHING OUTPUT SCREENSHOTS
CARTESIAN:
<img width="1282" height="743" alt="image" src="https://github.com/user-attachments/assets/897920a6-861c-465e-af4c-6bdd41f7c4e3" />


POLAR:
<img width="1282" height="743" alt="image" src="https://github.com/user-attachments/assets/bdecc6ff-aa84-4ffb-828d-65dda47ee465" />
