### PR TITLE
feat: implement axis gridlines

### DIFF
--- a/src/core/Core/Application.cpp
+++ b/src/core/Core/Application.cpp
@@ -138,41 +138,44 @@ ExitStatus App::Application::run() {
         const auto canvas_p1 = ImVec2(canvas_p0.x + canvas_sz.x, canvas_p0.y + canvas_sz.y);
         const ImVec2 origin(canvas_p0.x + canvas_sz.x * 0.5f, canvas_p0.y + canvas_sz.y * 0.5f);
         float lineThickness = 6.0f;
-        draw_list->AddLine(ImVec2(canvas_p0.x, origin.y), ImVec2(canvas_p1.x, origin.y), IM_COL32(0, 0, 0, 255), lineThickness);
-        draw_list->AddLine(ImVec2(origin.x, canvas_p0.y), ImVec2(origin.x, canvas_p1.y), IM_COL32(0, 0, 0, 255), lineThickness);
-
+        
         // --- Thin integer gridlines with adaptive spacing ---
         const ImU32 gridColor = IM_COL32(200, 200, 200, 255); // light gray
         const float gridThickness = 1.0f;                     // thin lines
         const float minPixelSpacing = 20.0f;                  // minimum spacing in pixels
-
+        
         // Dynamic step based on zoom
         float step = 1.0f;
         while (step * zoom < minPixelSpacing)
-            step *= 2.0f;
-
-        // Draw vertical gridlines
+        step *= 2.0f;
+        
+        
+        // Vertical gridlines
         for (float x = 0; origin.x + x * zoom < canvas_p1.x; x += step) {
+          if (x != 0) {
             draw_list->AddLine(ImVec2(origin.x + x * zoom, canvas_p0.y),
-                              ImVec2(origin.x + x * zoom, canvas_p1.y),
-                              gridColor, gridThickness);
-            if (x != 0)
-                draw_list->AddLine(ImVec2(origin.x - x * zoom, canvas_p0.y),
-                                  ImVec2(origin.x - x * zoom, canvas_p1.y),
-                                  gridColor, gridThickness);
+            ImVec2(origin.x + x * zoom, canvas_p1.y),
+            gridColor, gridThickness);
+            draw_list->AddLine(ImVec2(origin.x - x * zoom, canvas_p0.y),
+            ImVec2(origin.x - x * zoom, canvas_p1.y),
+            gridColor, gridThickness);
+          }
         }
-
-        // Draw horizontal gridlines
+        
+        // Horizontal gridlines
         for (float y = 0; origin.y + y * zoom < canvas_p1.y; y += step) {
+          if (y != 0) {
             draw_list->AddLine(ImVec2(canvas_p0.x, origin.y + y * zoom),
-                              ImVec2(canvas_p1.x, origin.y + y * zoom),
-                              gridColor, gridThickness);
-            if (y != 0)
-                draw_list->AddLine(ImVec2(canvas_p0.x, origin.y - y * zoom),
-                                  ImVec2(canvas_p1.x, origin.y - y * zoom),
-                                  gridColor, gridThickness);
+            ImVec2(canvas_p1.x, origin.y + y * zoom),
+            gridColor, gridThickness);
+            draw_list->AddLine(ImVec2(canvas_p0.x, origin.y - y * zoom),
+            ImVec2(canvas_p1.x, origin.y - y * zoom),
+            gridColor, gridThickness);
+          }
         }
-
+        
+        draw_list->AddLine(ImVec2(canvas_p0.x, origin.y), ImVec2(canvas_p1.x, origin.y), IM_COL32(0, 0, 0, 255), lineThickness);
+        draw_list->AddLine(ImVec2(origin.x, canvas_p0.y), ImVec2(origin.x, canvas_p1.y), IM_COL32(0, 0, 0, 255), lineThickness);
         std::vector<ImVec2> points;
 
         // (f(t), g(t))

--- a/src/core/Core/Application.cpp
+++ b/src/core/Core/Application.cpp
@@ -140,6 +140,39 @@ ExitStatus App::Application::run() {
         float lineThickness = 6.0f;
         draw_list->AddLine(ImVec2(canvas_p0.x, origin.y), ImVec2(canvas_p1.x, origin.y), IM_COL32(0, 0, 0, 255), lineThickness);
         draw_list->AddLine(ImVec2(origin.x, canvas_p0.y), ImVec2(origin.x, canvas_p1.y), IM_COL32(0, 0, 0, 255), lineThickness);
+
+        // --- Thin integer gridlines with adaptive spacing ---
+        const ImU32 gridColor = IM_COL32(200, 200, 200, 255); // light gray
+        const float gridThickness = 1.0f;                     // thin lines
+        const float minPixelSpacing = 20.0f;                  // minimum spacing in pixels
+
+        // Dynamic step based on zoom
+        float step = 1.0f;
+        while (step * zoom < minPixelSpacing)
+            step *= 2.0f;
+
+        // Draw vertical gridlines
+        for (float x = 0; origin.x + x * zoom < canvas_p1.x; x += step) {
+            draw_list->AddLine(ImVec2(origin.x + x * zoom, canvas_p0.y),
+                              ImVec2(origin.x + x * zoom, canvas_p1.y),
+                              gridColor, gridThickness);
+            if (x != 0)
+                draw_list->AddLine(ImVec2(origin.x - x * zoom, canvas_p0.y),
+                                  ImVec2(origin.x - x * zoom, canvas_p1.y),
+                                  gridColor, gridThickness);
+        }
+
+        // Draw horizontal gridlines
+        for (float y = 0; origin.y + y * zoom < canvas_p1.y; y += step) {
+            draw_list->AddLine(ImVec2(canvas_p0.x, origin.y + y * zoom),
+                              ImVec2(canvas_p1.x, origin.y + y * zoom),
+                              gridColor, gridThickness);
+            if (y != 0)
+                draw_list->AddLine(ImVec2(canvas_p0.x, origin.y - y * zoom),
+                                  ImVec2(canvas_p1.x, origin.y - y * zoom),
+                                  gridColor, gridThickness);
+        }
+
         std::vector<ImVec2> points;
 
         // (f(t), g(t))


### PR DESCRIPTION
## Description

Summary:

Implemented thin axis gridlines on the graph canvas that align with integer coordinates. Added adaptive grid spacing to prevent overcrowding at smaller zoom levels.

Details:
-> Added rendering logic for thin integer gridlines (light gray) on both axes.
-> Implemented adaptive spacing logic — gridline intervals dynamically increase when the zoom level is too small to keep visuals clean.
-> Updated graph rendering to maintain smooth performance even when zooming in or out.
-> Ensured the feature integrates with the existing SDL2 + ImGui rendering pipeline.

Testing:
-> Verified gridlines align with integer points.
-> Checked that lines don’t overcrowd at various zoom levels.
-> Confirmed smooth transitions during zoom in/out and function plotting.

Impact:
Improves graph readability and usability by providing clear, uncluttered grid visuals at all zoom scales.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> closes #5 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

